### PR TITLE
`sizeof` used on pointer instead of type.

### DIFF
--- a/src/lib/ggpo/backends/p2p.cpp
+++ b/src/lib/ggpo/backends/p2p.cpp
@@ -524,7 +524,7 @@ Peer2PeerBackend::GetNetworkStats(GGPONetworkStats *stats, GGPOPlayerHandle play
       return result;
    }
 
-   memset(stats, 0, sizeof stats);
+   memset(stats, 0, sizeof *stats);
    _endpoints[queue].GetNetworkStats(stats);
 
    return GGPO_OK;


### PR DESCRIPTION
This fixes a sizeof that was originally using the size of the pointer, and not that of the actual type.
So now the memset should clear the whole object.