### PR TITLE
Feature: Enhanced CMake Build Script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,68 +1,35 @@
 cmake_minimum_required(VERSION 3.2)
 
 # TODO: SDK Versioning.
-project(ggpo VERSION 1.0.0)
+project(GGPO VERSION 1.0.0)
 
-# What do we want to build?
-option(BUILD_GGPO "Enable the build of the GGPO SDK" ON)
-option(BUILD_VECTORWAR "Enable the build of the Vector War example app" ON)
-option(BUILD_SHARED_LIBS "Enable the build of shared libraries (.dll/.so) instead of static ones (.lib/.a)" ON)
+# Remove RelWithDebInfo and MinSizeRelease build types to match the original Visual Studio Project. 
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
 
-set(GGPO_SDK
-	src/include/ggponet.h
-	src/lib/ggpo/main.cpp
-	src/lib/ggpo/bitvector.h
-	src/lib/ggpo/bitvector.cpp
-	src/lib/ggpo/game_input.h
-	src/lib/ggpo/game_input.cpp
-	src/lib/ggpo/input_queue.h
-	src/lib/ggpo/input_queue.cpp
-	src/lib/ggpo/log.h
-	src/lib/ggpo/log.cpp
-	src/lib/ggpo/poll.h
-	src/lib/ggpo/poll.cpp
-	src/lib/ggpo/ring_buffer.h
-	src/lib/ggpo/static_buffer.h
-	src/lib/ggpo/sync.h
-	src/lib/ggpo/sync.cpp
-	src/lib/ggpo/timesync.h
-	src/lib/ggpo/timesync.cpp
-	src/lib/ggpo/types.h
-	src/lib/ggpo/zconf.h
-	src/lib/ggpo/zlib.h
-	src/lib/ggpo/backends/backend.h
-	src/lib/ggpo/backends/p2p.h
-	src/lib/ggpo/backends/p2p.cpp
-	src/lib/ggpo/backends/spectator.h
-	src/lib/ggpo/backends/spectator.cpp
-	src/lib/ggpo/backends/synctest.h
-	src/lib/ggpo/backends/synctest.cpp
-	src/lib/ggpo/network/udp.h
-	src/lib/ggpo/network/udp.cpp
-	src/lib/ggpo/network/udp_msg.h
-	src/lib/ggpo/network/udp_proto.h
-	src/lib/ggpo/network/udp_proto.cpp
-)
+include(src/cmake/properties.cmake)
+include(src/cmake/helper_methods.cmake)
 
-if(BUILD_GGPO)
-	add_library(ggpo ${GGPO_SDK})
-	
-	target_include_directories(ggpo PUBLIC src/include)
-	target_include_directories(ggpo PUBLIC src/lib/ggpo)
-	
-	if(WIN32 AND BUILD_SHARED_LIBS)
-		# Link to Multimedia API and Winsocks during a static build.
-		target_link_libraries(ggpo LINK_PUBLIC winmm.lib ws2_32.lib)
+if(WIN32)
+	## Prevent the CMake trying to install GGPO in Program Files on Windows
+	if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+		set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/installed" CACHE PATH "Default install path" FORCE)
 	endif()
-	
-	set_target_properties(ggpo PROPERTIES VERSION ${PROJECT_VERSION})
 endif()
 
-if(BUILD_VECTORWAR)
-	# Vector War is windows only.
+# What do we want to build?
+option(GGPO_BUILD_SDK "Enable the build of the GGPO SDK" ON)
+option(GGPO_BUILD_VECTORWAR "Enable the build of the Vector War example app" ON)
+option(BUILD_SHARED_LIBS "Enable the build of shared libraries (.dll/.so) instead of static ones (.lib/.a)" ON)
+
+if(GGPO_BUILD_SDK)
+	add_subdirectory(src)
+endif()
+
+if(GGPO_BUILD_VECTORWAR)
+	# Vector War is Windows only.
 	if(WIN32)
 		add_subdirectory(src/apps/vectorwar)
 	else()
-		message(WARNING "The Vector War app only supports windows, skipping...")
+		message(WARNING "The Vector War app only supports Windows, skipping...")
 	endif()
 endif()

--- a/bin/start_vectorwar_2p.cmd
+++ b/bin/start_vectorwar_2p.cmd
@@ -6,7 +6,7 @@ REM           Press 'D' to fire
 REM           Press 'P' to show performance monitor
 REM           Shift to strafe
 
-pushd ..\build\src\apps\vectorwar\Release
+pushd ..\build\bin\x64\Release
 del *.log
 start VectorWar.exe 7000 2 local 127.0.0.1:7001 
 start VectorWar.exe 7001 2 127.0.0.1:7000 local

--- a/bin/start_vectorwar_2p_4s.cmd
+++ b/bin/start_vectorwar_2p_4s.cmd
@@ -8,7 +8,7 @@ REM           Press 'D' to fire
 REM           Press 'P' to show performance monitor
 REM           Shift to strafe
 
-pushd ..\build\src\apps\vectorwar\Release
+pushd ..\build\bin\x64\Release
 del *.log
 
 :: no spectators

--- a/bin/start_vectorwar_3p.cmd
+++ b/bin/start_vectorwar_3p.cmd
@@ -8,7 +8,7 @@ REM           Press 'D' to fire
 REM           Press 'P' to show performance monitor
 REM           Shift to strafe
 
-pushd ..\build\src\apps\vectorwar\Release
+pushd ..\build\bin\x64\Release
 del *.log
 start VectorWar.exe 7000 3 local 127.0.0.1:7001 127.0.0.1:7002 
 start VectorWar.exe 7001 3 127.0.0.1:7000 local 127.0.0.1:7002 

--- a/bin/start_vectorwar_4p.cmd
+++ b/bin/start_vectorwar_4p.cmd
@@ -8,7 +8,7 @@ REM           Press 'D' to fire
 REM           Press 'P' to show performance monitor
 REM           Shift to strafe
 
-pushd ..\build\src\apps\vectorwar\Release
+pushd ..\build\bin\x64\Release
 del *.log
 
 start VectorWar.exe 7000 4 local 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,56 @@
+include(CMakeSources.cmake)
+
+add_library(GGPO
+	${GGPO_LIB_SRC}
+)
+
+add_common_flags(GGPO)
+
+target_include_directories(GGPO PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/ggpo>
+)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+	# Link to Multimedia API and Winsocks during a shared build.
+	target_link_libraries(GGPO PUBLIC winmm.lib ws2_32.lib)
+endif()
+
+set_target_properties(GGPO PROPERTIES VERSION ${PROJECT_VERSION})
+
+# Install
+install(
+	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
+	DESTINATION ./
+	FILES_MATCHING
+	PATTERN "*.h"
+	PATTERN "*.hpp"
+)
+
+install(
+	TARGETS GGPO
+	EXPORT ggpo
+	RUNTIME DESTINATION bin
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+)
+
+if(MSVC)
+	if(BUILD_SHARED_LIBS)
+		install(
+			FILES $<TARGET_PDB_FILE:GGPO>
+			DESTINATION lib
+			OPTIONAL
+		)
+	else()
+		## NOTE: This is rather hacky, since CMake doesn't allow to install the PDB files for
+		##	     static libraries, so we get the debug PDB file and copy it there.
+		install(
+			FILES "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG}/GGPO.pdb"
+			DESTINATION lib
+			OPTIONAL
+		)
+	endif()
+else()
+## TODO place the symbols install when GGPO became cross-platform
+endif()

--- a/src/CMakeSources.cmake
+++ b/src/CMakeSources.cmake
@@ -1,0 +1,67 @@
+set(GGPO_LIB_INC_NOFILTER
+	"lib/ggpo/bitvector.h"
+	"lib/ggpo/game_input.h"
+	"lib/ggpo/input_queue.h"
+	"lib/ggpo/log.h"
+	"lib/ggpo/poll.h"
+	"lib/ggpo/ring_buffer.h"
+	"lib/ggpo/sync.h"
+	"lib/ggpo/timesync.h"
+	"lib/ggpo/types.h"
+	"lib/ggpo/zconf.h"
+	"lib/ggpo/zlib.h"
+)
+
+set(GGPO_LIB_SRC_NOFILTER
+	"lib/ggpo/bitvector.cpp"
+	"lib/ggpo/game_input.cpp"
+	"lib/ggpo/input_queue.cpp"
+	"lib/ggpo/log.cpp"
+	"lib/ggpo/main.cpp"
+	"lib/ggpo/poll.cpp"
+	"lib/ggpo/sync.cpp"
+	"lib/ggpo/timesync.cpp"
+)
+
+set(GGPO_LIB_INC_NETWORK
+	"lib/ggpo/network/udp.h"
+	"lib/ggpo/network/udp_msg.h"
+	"lib/ggpo/network/udp_proto.h"
+)
+
+set(GGPO_LIB_SRC_NETWORK
+	"lib/ggpo/network/udp.cpp"
+	"lib/ggpo/network/udp_proto.cpp"
+)
+
+set(GGPO_LIB_INC_BACKENDS
+	"lib/ggpo/backends/backend.h"
+	"lib/ggpo/backends/p2p.h"
+	"lib/ggpo/backends/spectator.h"
+	"lib/ggpo/backends/synctest.h"
+)
+
+set(GGPO_LIB_SRC_BACKENDS
+	"lib/ggpo/backends/p2p.cpp"
+	"lib/ggpo/backends/spectator.cpp"
+	"lib/ggpo/backends/synctest.cpp"
+)
+
+set(GGPO_PUBLIC_INC
+	"include/ggponet.h"
+)
+
+source_group(" " FILES ${GGPO_LIB_INC_NOFILTER} ${GGPO_LIB_SRC_NOFILTER})
+source_group("Network" FILES ${GGPO_LIB_INC_NETWORK} ${GGPO_LIB_SRC_NETWORK})
+source_group("Backends" FILES ${GGPO_LIB_INC_BACKENDS} ${GGPO_LIB_SRC_BACKENDS})
+source_group("Public" FILES ${GGPO_PUBLIC_INC})
+
+set(GGPO_LIB_SRC
+	${GGPO_LIB_INC_NOFILTER}
+	${GGPO_LIB_SRC_NOFILTER}
+	${GGPO_LIB_INC_NETWORK}
+	${GGPO_LIB_SRC_NETWORK}
+	${GGPO_LIB_INC_BACKENDS}
+	${GGPO_LIB_SRC_BACKENDS}
+	${GGPO_PUBLIC_INC}
+)

--- a/src/apps/vectorwar/CMakeLists.txt
+++ b/src/apps/vectorwar/CMakeLists.txt
@@ -1,24 +1,12 @@
-set(VECTORWAR_APP
-	main.cpp
-	gamestate.h
-	gamestate.cpp
-	gdi_renderer.h
-	gdi_renderer.cpp
-	ggpo_perfmon.h
-	ggpo_perfmon.cpp
-	nongamestate.h
-	renderer.h
-	Resource.h
-	targetver.h
-	vectorwar.h
-	vectorwar.cpp
-	VectorWar.rc
+include(CMakeSources.cmake)
+
+add_executable(VectorWar WIN32 
+	${GGPO_EXAMPLES_VECTORWAR_SRC}
 )
 
-add_executable(vectorwar WIN32 ${VECTORWAR_APP})
-
+add_common_flags(VectorWar)
 # Change the character set to unicode.
 add_definitions(-D_UNICODE -DUNICODE)
 
 # Link against GGPO, winmm (Windows Multimedia API), and ws2_32 (Winsock).
-target_link_libraries(vectorwar LINK_PUBLIC ggpo winmm.lib ws2_32.lib)
+target_link_libraries(VectorWar LINK_PUBLIC GGPO winmm.lib ws2_32.lib)

--- a/src/apps/vectorwar/CMakeSources.cmake
+++ b/src/apps/vectorwar/CMakeSources.cmake
@@ -1,0 +1,30 @@
+set(GGPO_EXAMPLES_VECTORWAR_INC_NOFILTER
+	"gamestate.h"
+	"gdi_renderer.h"
+	"ggpo_perfmon.h"
+	"nongamestate.h"
+	"renderer.h"
+	"Resource.h"
+	"targetver.h"
+	"vectorwar.h"
+)
+
+set(GGPO_EXAMPLES_VECTORWAR_SRC_NOFILTER
+	"gamestate.cpp"
+	"gdi_renderer.cpp"
+	"ggpo_perfmon.cpp"
+	"main.cpp"
+	"vectorwar.cpp"
+)
+
+set(GGPO_EXAMPLES_VECTORWAR_WIN32RES
+	"VectorWar.rc"
+)
+
+source_group(" " FILES ${GGPO_EXAMPLES_VECTORWAR_INC_NOFILTER} ${GGPO_EXAMPLES_VECTORWAR_SRC_NOFILTER} ${GGPO_EXAMPLES_VECTORWAR_WIN32RES})
+
+set(GGPO_EXAMPLES_VECTORWAR_SRC
+	${GGPO_EXAMPLES_VECTORWAR_INC_NOFILTER}
+	${GGPO_EXAMPLES_VECTORWAR_SRC_NOFILTER}
+	${GGPO_EXAMPLES_VECTORWAR_WIN32RES}
+)

--- a/src/cmake/helper_methods.cmake
+++ b/src/cmake/helper_methods.cmake
@@ -1,0 +1,20 @@
+function(add_common_flags target)
+	get_target_property(target_type ${target} TYPE)
+
+	if(MSVC)
+		set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/DEBUG /INCREMENTAL")
+		set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE "/DEBUG /LTCG /INCREMENTAL:NO /OPT:REF")
+		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS -DWIN32 -D_WINDOWS)
+		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS /GS- /W3 /WX- /MP /nologo /bigobj /wd4577 /wd4530)
+		
+		if(GGPO_64BIT) # Debug edit and continue for 64-bit
+			set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Debug>:/ZI>)
+		else() # Normal debug for 32-bit
+			set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Debug>:/Zi>)
+		endif()
+		
+		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Release>:/GL /Gy /Zi /O2 /Oi /MD -DNDEBUG>)
+	else()
+		# TODO_OTHER_COMPILERS_GO_HERE
+	endif()
+endfunction()

--- a/src/cmake/properties.cmake
+++ b/src/cmake/properties.cmake
@@ -1,0 +1,48 @@
+## Based on https://github.com/GameFoundry/bsf/blob/master/Source/CMake/Properties.cmake
+## which is covered under the MIT License, same as GGPO.
+
+include(CheckCXXCompilerFlag)
+
+# Configuration types
+if(NOT CMAKE_CONFIGURATION_TYPES) # Multiconfig generator?
+	if(NOT CMAKE_BUILD_TYPE)
+		message(STATUS "Defaulting to release build.")
+		set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+	endif()
+endif()
+
+if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+	set(GGPO_64BIT true)
+endif()
+
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+# Enable colored output
+if (CMAKE_GENERATOR STREQUAL "Ninja")
+	check_cxx_compiler_flag("-fdiagnostics-color=always" F_DIAGNOSTIC_COLOR_ALWAYS)
+	if (F_DIAGNOSTIC_COLOR_ALWAYS)
+		add_compile_options("-fdiagnostics-color=always")
+	endif()
+endif()
+
+# Output
+if(GGPO_64BIT)
+	set(GGPO_OUTPUT_DIR_PREFIX x64)
+else()
+	set(GGPO_OUTPUT_DIR_PREFIX x86)
+endif()
+
+set(GGPO_BINARY_OUTPUT_DIR ${PROJECT_BINARY_DIR}/bin/${GGPO_OUTPUT_DIR_PREFIX})
+set(GGPO_LIBRARY_OUTPUT_DIR ${PROJECT_BINARY_DIR}/lib/${GGPO_OUTPUT_DIR_PREFIX})
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${GGPO_BINARY_OUTPUT_DIR}/Debug)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${GGPO_BINARY_OUTPUT_DIR}/Release)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${GGPO_BINARY_OUTPUT_DIR}/Debug)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${GGPO_BINARY_OUTPUT_DIR}/Release)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${GGPO_LIBRARY_OUTPUT_DIR}/Debug)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${GGPO_LIBRARY_OUTPUT_DIR}/Release)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS TRUE)


### PR DESCRIPTION
This extends and refactors the original CMake script to make it nicer.
The structure of it is loosely based on that used in bs::framework project.

- Separate the Main SDK build definitions to its own ```CMakeLists.txt```.
  Source file lists for each project were also moved to file ```CMakeSources.cmake```,
  cataloged based on a folder they're in and the filter definitions for VS were added.
- During build the executable/library artifacts are now stored in
  ```<BUILD_DIR>/<BIN_OR_LIB>/<ARCHITECTURE>/<BUILD_TYPE>```. The scripts were
  modified to reflect that change.
- Added most of the build flags from the original VS project
  with some new ones.
- Added some properties to explicitly configure the build environment.
- Add ability to install the libraries for distribution.
- Other small renaming, cleanups and things that I've forgotten.