### PR TITLE
Stops build_windows.cmd from closing immediately after completion

### DIFF
--- a/build_windows.cmd
+++ b/build_windows.cmd
@@ -1,2 +1,3 @@
 @echo off
 cmake -G "Visual Studio 16 2019" -A x64 -B build -DBUILD_SHARED_LIBS=off
+pause 


### PR DESCRIPTION
Adds 'pause' command at the end of build_windows.cmd that stops it from closing after completion so that users can easily see build output and/or errors. 