### PR TITLE
Use types.h min/max over windef.h

### DIFF
--- a/src/lib/ggpo/backends/p2p.cpp
+++ b/src/lib/ggpo/backends/p2p.cpp
@@ -148,7 +148,7 @@ Peer2PeerBackend::DoPoll(int timeout)
          if (current_frame > _next_recommended_sleep) {
             int interval = 0;
             for (int i = 0; i < _num_players; i++) {
-               interval = max(interval, _endpoints[i].RecommendFrameDelay());
+               interval = MAX(interval, _endpoints[i].RecommendFrameDelay());
             }
 
             if (interval > 0) {
@@ -181,7 +181,7 @@ int Peer2PeerBackend::Poll2Players(int current_frame)
          queue_connected = _endpoints[i].GetPeerConnectStatus(i, &ignore);
       }
       if (!_local_connect_status[i].disconnected) {
-         total_min_confirmed = min(_local_connect_status[i].last_frame, total_min_confirmed);
+         total_min_confirmed = MIN(_local_connect_status[i].last_frame, total_min_confirmed);
       }
       Log("  local endp: connected = %d, last_received = %d, total_min_confirmed = %d.\n", !_local_connect_status[i].disconnected, _local_connect_status[i].last_frame, total_min_confirmed);
       if (!queue_connected && !_local_connect_status[i].disconnected) {
@@ -211,7 +211,7 @@ int Peer2PeerBackend::PollNPlayers(int current_frame)
             bool connected = _endpoints[i].GetPeerConnectStatus(queue, &last_received);
 
             queue_connected = queue_connected && connected;
-            queue_min_confirmed = min(last_received, queue_min_confirmed);
+            queue_min_confirmed = MIN(last_received, queue_min_confirmed);
             Log("  endpoint %d: connected = %d, last_received = %d, queue_min_confirmed = %d.\n", i, connected, last_received, queue_min_confirmed);
          } else {
             Log("  endpoint %d: ignoring... not running.\n", i);
@@ -219,12 +219,12 @@ int Peer2PeerBackend::PollNPlayers(int current_frame)
       }
       // merge in our local status only if we're still connected!
       if (!_local_connect_status[queue].disconnected) {
-         queue_min_confirmed = min(_local_connect_status[queue].last_frame, queue_min_confirmed);
+         queue_min_confirmed = MIN(_local_connect_status[queue].last_frame, queue_min_confirmed);
       }
       Log("  local endp: connected = %d, last_received = %d, queue_min_confirmed = %d.\n", !_local_connect_status[queue].disconnected, _local_connect_status[queue].last_frame, queue_min_confirmed);
 
       if (queue_connected) {
-         total_min_confirmed = min(queue_min_confirmed, total_min_confirmed);
+         total_min_confirmed = MIN(queue_min_confirmed, total_min_confirmed);
       } else {
          // check to see if this disconnect notification is further back than we've been before.  If
          // so, we need to re-adjust.  This can happen when we detect our own disconnect at frame n

--- a/src/lib/ggpo/input_queue.cpp
+++ b/src/lib/ggpo/input_queue.cpp
@@ -64,7 +64,7 @@ InputQueue::DiscardConfirmedFrames(int frame)
    ASSERT(frame >= 0);
 
    if (_last_frame_requested != GameInput::NullFrame) {
-      frame = min(frame, _last_frame_requested);
+      frame = MIN(frame, _last_frame_requested);
    }
 
    Log("discarding confirmed frames up to %d (last_added:%d length:%d [head:%d tail:%d]).\n", 

--- a/src/lib/ggpo/network/udp_proto.cpp
+++ b/src/lib/ggpo/network/udp_proto.cpp
@@ -537,7 +537,7 @@ UdpProtocol::OnInput(UdpMsg *msg, int len)
       for (int i = 0; i < ARRAYSIZE(_peer_connect_status); i++) {
          ASSERT(remote_status[i].last_frame >= _peer_connect_status[i].last_frame);
          _peer_connect_status[i].disconnected = _peer_connect_status[i].disconnected || remote_status[i].disconnected;
-         _peer_connect_status[i].last_frame = max(_peer_connect_status[i].last_frame, remote_status[i].last_frame);
+         _peer_connect_status[i].last_frame = MAX(_peer_connect_status[i].last_frame, remote_status[i].last_frame);
       }
    }
 

--- a/src/lib/ggpo/poll.cpp
+++ b/src/lib/ggpo/poll.cpp
@@ -65,7 +65,7 @@ Poll::Pump(int timeout)
    int elapsed = timeGetTime() - _start_time;
    int maxwait = ComputeWaitTime(elapsed);
    if (maxwait != INFINITE) {
-      timeout = min(timeout, maxwait);
+      timeout = MIN(timeout, maxwait);
    }
 
    res = WaitForMultipleObjects(_handle_count, _handles, false, timeout);

--- a/src/lib/ggpo/timesync.cpp
+++ b/src/lib/ggpo/timesync.cpp
@@ -83,5 +83,5 @@ TimeSync::recommend_frame_wait_duration(bool require_idle_input)
    }
 
    // Success!!! Recommend the number of frames to sleep and adjust
-   return min(sleep_frames, MAX_FRAME_ADVANTAGE);
+   return MIN(sleep_frames, MAX_FRAME_ADVANTAGE);
 }

--- a/src/lib/ggpo/types.h
+++ b/src/lib/ggpo/types.h
@@ -8,10 +8,10 @@
 #ifndef _TYPES_H
 #define _TYPES_H
 
-
 #include <winsock2.h>
 #include <windows.h>
 #include <stdio.h>
+
 #include "log.h"
 
 /*
@@ -40,15 +40,15 @@ typedef char int8;
 typedef short int16;
 typedef int int32;
 
+
 /*
  * Macros
  */
 #if defined(_DEBUG)
-#define BREAK  DebugBreak();
+#  define BREAK  DebugBreak();
 #else
-#define BREAK  exit(1);
+#  define BREAK  exit(1);
 #endif
-
 
 #define ASSERT(x)                                           \
    do {                                                     \
@@ -73,7 +73,11 @@ typedef int int32;
 #endif
 
 #ifndef MAX
-#  define MAX(x, y)        ((x) > (y) ? (x) : (y))
+#  define MAX(x, y)        (((x) > (y)) ? (x) : (y))
 #endif
 
+#ifndef MIN
+#  define MIN(x, y)        (((x) < (y)) ? (x) : (y))
 #endif
+
+#endif // _TYPES_H

--- a/src/lib/ggpo/types.h
+++ b/src/lib/ggpo/types.h
@@ -44,12 +44,6 @@ typedef int int32;
 /*
  * Macros
  */
-#if defined(_DEBUG)
-#  define BREAK  DebugBreak();
-#else
-#  define BREAK  exit(1);
-#endif
-
 #define ASSERT(x)                                           \
    do {                                                     \
       if (!(x)) {                                           \


### PR DESCRIPTION
- One step closer to cross platform support.
- Vector War still uses windef.h min/max, not sure what we want to do there.