### PR TITLE
Typo, synchronizing should be syncrhonized.

### DIFF
--- a/src/apps/vectorwar/vectorwar.cpp
+++ b/src/apps/vectorwar/vectorwar.cpp
@@ -74,7 +74,7 @@ vw_on_event_callback(GGPOEvent *info)
       ngs.UpdateConnectProgress(info->u.synchronizing.player, progress);
       break;
    case GGPO_EVENTCODE_SYNCHRONIZED_WITH_PEER:
-      ngs.UpdateConnectProgress(info->u.synchronizing.player, 100);
+      ngs.UpdateConnectProgress(info->u.synchronized.player, 100);
       break;
    case GGPO_EVENTCODE_RUNNING:
       ngs.SetConnectState(Running);


### PR DESCRIPTION
just a simple typo which because of the union doesn't actually change the results.