### PR TITLE
Return correct value in UdpMsg::PayloadSize for SyncRequest type packets

### DIFF
--- a/src/lib/ggpo/network/udp_msg.h
+++ b/src/lib/ggpo/network/udp_msg.h
@@ -84,7 +84,7 @@ public:
       int size;
 
       switch (hdr.type) {
-      case SyncRequest:   return sizeof(u.sync_reply);
+      case SyncRequest:   return sizeof(u.sync_request);
       case SyncReply:     return sizeof(u.sync_reply);
       case QualityReport: return sizeof(u.quality_report);
       case QualityReply:  return sizeof(u.quality_reply);


### PR DESCRIPTION
I believe this to be in error, as it would be requesting the size of the SyncReply's union. I don't know if this has actual issues, aside from telling the user to make room for a few extra bytes on udp SendTo callback. Nonetheless, it is incorrectly written.

It looks like another case of the Last Line Effect (as noted in https://www.viva64.com/en/b/0260/)