### PR TITLE
Added cross platform dll export

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,9 @@ endif()
 
 set_target_properties(GGPO PROPERTIES VERSION ${PROJECT_VERSION})
 
+# Export the SDK.
+add_definitions(-DGGPO_SDK_EXPORT)
+
 # Install
 install(
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/include/ggponet.h
+++ b/src/include/ggponet.h
@@ -14,6 +14,18 @@ extern "C" {
 
 #include <stdarg.h>
 
+// On windows, export at build time and import at runtime.
+// ELF systems don't need an explicit export/import.
+#ifdef _WIN32
+#  ifdef GGPO_SDK_EXPORT
+#    define GGPO_EXPORT __declspec(dllexport)
+#  else
+#    define GGPO_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define GGPO_EXPORT
+#endif
+
 #define GGPO_MAX_PLAYERS                  4
 #define GGPO_MAX_PREDICTION_FRAMES        8
 #define GGPO_MAX_SPECTATORS              32
@@ -303,12 +315,12 @@ typedef struct GGPONetworkStats {
  *
  * local_port - The port GGPO should bind to for UDP traffic.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_start_session(GGPOSession **session,
-                                                               GGPOSessionCallbacks *cb,
-                                                               const char *game,
-                                                               int num_players,
-                                                               int input_size,
-                                                               int localport);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_start_session(GGPOSession **session,
+                                                     GGPOSessionCallbacks *cb,
+                                                     const char *game,
+                                                     int num_players,
+                                                     int input_size,
+                                                     int localport);
 
 
 /*
@@ -322,9 +334,9 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_start_session(GGPOSession **ses
  * handle - An out parameter to a handle used to identify this player in the future.
  * (e.g. in the on_event callbacks).
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_add_player(GGPOSession *session,
-                                                            GGPOPlayer *player,
-                                                            GGPOPlayerHandle *handle);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_add_player(GGPOSession *session,
+                                                  GGPOPlayer *player,
+                                                  GGPOPlayerHandle *handle);
 
 
 /*
@@ -351,12 +363,12 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_add_player(GGPOSession *session
  * recommended value is 1.
  *
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_start_synctest(GGPOSession **session,
-                                                                GGPOSessionCallbacks *cb,
-                                                                char *game,
-                                                                int num_players,
-                                                                int input_size,
-                                                                int frames);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_start_synctest(GGPOSession **session,
+                                                      GGPOSessionCallbacks *cb,
+                                                      char *game,
+                                                      int num_players,
+                                                      int input_size,
+                                                      int frames);
 
 
 /*
@@ -383,21 +395,21 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_start_synctest(GGPOSession **se
  *
  * host_port - The port of the session on the host
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_start_spectating(GGPOSession **session,
-                                                                  GGPOSessionCallbacks *cb,
-                                                                  const char *game,
-                                                                  int num_players,
-                                                                  int input_size,
-                                                                  int local_port,
-                                                                  char *host_ip,
-                                                                  int host_port);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_start_spectating(GGPOSession **session,
+                                                        GGPOSessionCallbacks *cb,
+                                                        const char *game,
+                                                        int num_players,
+                                                        int input_size,
+                                                        int local_port,
+                                                        char *host_ip,
+                                                        int host_port);
 
 /*
  * ggpo_close_session --
  * Used to close a session.  You must call ggpo_close_session to
  * free the resources allocated in ggpo_start_session.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_close_session(GGPOSession *);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_close_session(GGPOSession *);
 
 
 /*
@@ -406,9 +418,9 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_close_session(GGPOSession *);
  * Change the amount of frames ggpo will delay local input.  Must be called
  * before the first call to ggpo_synchronize_input.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_frame_delay(GGPOSession *,
-                                                                 GGPOPlayerHandle player,
-                                                                 int frame_delay);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_set_frame_delay(GGPOSession *,
+                                                       GGPOPlayerHandle player,
+                                                       int frame_delay);
 
 /*
  * ggpo_idle --
@@ -419,8 +431,8 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_frame_delay(GGPOSession *,
  * timeout - The amount of time GGPO.net is allowed to spend in this function,
  * in milliseconds.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_idle(GGPOSession *,
-                                                      int timeout);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_idle(GGPOSession *,
+                                            int timeout);
 
 /*
  * ggpo_add_local_input --
@@ -437,10 +449,10 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_idle(GGPOSession *,
  * size - The size of the controller inputs.  This must be exactly equal to the
  * size passed into ggpo_start_session.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_add_local_input(GGPOSession *,
-                                                                 GGPOPlayerHandle player,
-                                                                 void *values,
-                                                                 int size);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_add_local_input(GGPOSession *,
+                                                       GGPOPlayerHandle player,
+                                                       void *values,
+                                                       int size);
 
 /*
  * ggpo_synchronize_input --
@@ -459,10 +471,10 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_add_local_input(GGPOSession *,
  * that player will be zeroed and the i-th flag will be set.  For example,
  * if only player 3 has disconnected, disconnect flags will be 8 (i.e. 1 << 3).
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_synchronize_input(GGPOSession *,
-                                                                   void *values,
-                                                                   int size,
-                                                                   int *disconnect_flags);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_synchronize_input(GGPOSession *,
+                                                         void *values,
+                                                         int size,
+                                                         int *disconnect_flags);
 
 /*
  * ggpo_disconnect_player --
@@ -470,8 +482,8 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_synchronize_input(GGPOSession *
  * Disconnects a remote player from a game.  Will return GGPO_ERRORCODE_PLAYER_DISCONNECTED
  * if you try to disconnect a player who has already been disconnected.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_disconnect_player(GGPOSession *,
-                                                                   GGPOPlayerHandle player);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_disconnect_player(GGPOSession *,
+                                                         GGPOPlayerHandle player);
 
 /*
  * ggpo_advance_frame --
@@ -481,7 +493,7 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_disconnect_player(GGPOSession *
  * you advance the gamestate by a frame, even during rollbacks.  GGPO.net
  * may call your save_state callback before this function returns.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_advance_frame(GGPOSession *);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_advance_frame(GGPOSession *);
 
 /*
  * ggpo_get_network_stats --
@@ -493,9 +505,9 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_advance_frame(GGPOSession *);
  *
  * stats - Out parameter to the network statistics.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_get_network_stats(GGPOSession *,
-                                                                   GGPOPlayerHandle player,
-                                                                   GGPONetworkStats *stats);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_get_network_stats(GGPOSession *,
+                                                         GGPOPlayerHandle player,
+                                                         GGPONetworkStats *stats);
 
 /*
  * ggpo_set_disconnect_timeout --
@@ -509,8 +521,8 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_get_network_stats(GGPOSession *
  *
  * timeout - The time in milliseconds to wait before disconnecting a peer.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_disconnect_timeout(GGPOSession *,
-                                                                        int timeout);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_set_disconnect_timeout(GGPOSession *,
+                                                              int timeout);
 
 /*
  * ggpo_set_disconnect_notify_start --
@@ -521,8 +533,8 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_disconnect_timeout(GGPOSess
  * timeout - The amount of time which needs to elapse without receiving a packet
  *           before the GGPO_EVENTCODE_NETWORK_INTERRUPTED event is sent.
  */
-__declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_disconnect_notify_start(GGPOSession *,
-                                                                             int timeout);
+GGPO_EXPORT GGPOErrorCode __cdecl ggpo_set_disconnect_notify_start(GGPOSession *,
+                                                                   int timeout);
 
 /*
  * ggpo_log --
@@ -532,17 +544,17 @@ __declspec(dllexport) GGPOErrorCode __cdecl ggpo_set_disconnect_notify_start(GGP
  * variable is set to 1.  This will change in future versions of the
  * SDK.
  */
-__declspec(dllexport) void __cdecl ggpo_log(GGPOSession *,
-                                            const char *fmt, ...);
+GGPO_EXPORT void __cdecl ggpo_log(GGPOSession *,
+                                  const char *fmt, ...);
 /*
  * ggpo_logv --
  *
  * A varargs compatible version of ggpo_log.  See ggpo_log for
  * more details.
  */
-__declspec(dllexport) void __cdecl ggpo_logv(GGPOSession *,
-                                             const char *fmt,
-                                             va_list args);
+GGPO_EXPORT void __cdecl ggpo_logv(GGPOSession *,
+                                   const char *fmt,
+                                   va_list args);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
Added cross-platform dll export. When compiling the SDK, ```GGPO_SDK_EXPORT``` should be defined otherwise, the ggponet header will import rather than export.