### PR TITLE
Fix local frame advantage estimation

### DIFF
--- a/src/lib/ggpo/network/udp_proto.cpp
+++ b/src/lib/ggpo/network/udp_proto.cpp
@@ -680,7 +680,7 @@ UdpProtocol::SetLocalFrameNumber(int localFrame)
     * last frame they gave us plus some delta for the one-way packet
     * trip time.
     */
-   int remoteFrame = _last_received_input.frame + (_round_trip_time * 60 / 1000);
+   int remoteFrame = _last_received_input.frame + (_round_trip_time * (60 / 2) / 1000);
 
    /*
     * Our frame advantage is how many frames *behind* the other guy


### PR DESCRIPTION
UdpProtocol::_local_frame_advantage estimation was previously using the full packet round trip time instead of an estimation of the one-way packet trip time, so I edited the line of code to match the behavior described in the comment on the line above. This theoretically wasn't causing any issues in the first place, as all players would have similar errors in their local estimations and they would cancel each other out.