### PR TITLE
fix issue of winsocks not being initialized

### DIFF
--- a/src/include/ggponet.h
+++ b/src/include/ggponet.h
@@ -296,6 +296,12 @@ typedef struct GGPONetworkStats {
    } timesync;
 } GGPONetworkStats;
 
+// Windows specific API to initialize windows sockets for network programming
+GGPO_API GGPOErrorCode __cdecl ggpo_initialize_winsock();
+
+// Windows specific API to deinitialize windows sockets for network programming
+GGPO_API GGPOErrorCode __cdecl ggpo_deinitialize_winsock();
+
 /*
  * ggpo_start_session --
  *

--- a/src/lib/ggpo/main.cpp
+++ b/src/lib/ggpo/main.cpp
@@ -36,6 +36,40 @@ ggpo_logv(GGPOSession *ggpo, const char *fmt, va_list args)
 }
 
 GGPOErrorCode
+ggpo_initialize_winsock()
+{
+#ifdef WIN32
+    WORD wVersionRequested = MAKEWORD(2, 2);
+    WSADATA wsaData;
+    int err = WSAStartup(wVersionRequested, &wsaData);
+
+    if (err != 0) {
+        // Can comment out following lines for debugging purposes
+        //printf("WSAStartup failed with error: %d\n", err);
+        //DWORD lastError = WSAGetLastError();
+        //printf("last error code: %d\n", lastError);
+        ASSERT(FALSE && "Error initializing winsockets");
+    }
+#endif
+
+    return GGPO_ERRORCODE_SUCCESS;
+}
+
+GGPOErrorCode
+ggpo_deinitialize_winsock()
+{
+#ifdef WIN32
+    // https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup
+    int result = WSACleanup();
+    if (result != 0) {
+        ASSERT(FALSE && "Error de-initializing winsockets");
+    }
+#endif
+
+    return GGPO_ERRORCODE_SUCCESS;
+}
+
+GGPOErrorCode
 ggpo_start_session(GGPOSession **session,
                    GGPOSessionCallbacks *cb,
                    const char *game,


### PR DESCRIPTION
Fixes the following issue when you try to run ggpo separately from vectorwars (e.g. building your own `ggpo.lib` and `ggpo.dll` files):

![image](https://user-images.githubusercontent.com/6732525/148664164-e025d625-e9cb-4fe9-bd9a-d40db7a823bd.png)

### Proposed Fix
* Before `ggpo_start_session()` function is called make sure to call `gpo_initialize_winsock()` first.